### PR TITLE
Update upgrading doc for latest misago-docker changes

### DIFF
--- a/docs/setup/Upgrading.md
+++ b/docs/setup/Upgrading.md
@@ -7,7 +7,7 @@ To upgrade your Misago site, connect to the server, do `cd ~/misago_docker` to m
 ./appctl upgrade
 ```
 
-You will be asked to confirm that you wish to upgrade your site to latest available version.
+You will be asked to confirm that you wish to upgrade your site to the latest available version.
 
 Upgrade process will back up your data, then pull latest code from [GitHub repository](https://github.com/rafalp/misago_docker). After pull completes successfully, your site will be stopped and updated to latest version.
 

--- a/docs/setup/Upgrading.md
+++ b/docs/setup/Upgrading.md
@@ -1,13 +1,18 @@
 Upgrading your Misago to latest version
 =======================================
 
-To upgrade your Misago site, connect to the server, do `cd ~/misago_docker` to move to Misago directory, and run following commands:
+To upgrade your Misago site, connect to the server, do `cd ~/misago_docker` to move to Misago directory, and run following command:
 
-1. `git pull`
-2. `./appctl upgrade`
+```
+./appctl upgrade
+```
 
-`git pull` will download latest version of Misago from the GitHub, and `./appctl upgrade` will run upgrades.
+You will be asked to confirm that you wish to upgrade your site to latest available version.
+
+Upgrade process will back up your data, then pull latest code from [GitHub repository](https://github.com/rafalp/misago_docker). After pull completes successfully, your site will be stopped and updated to latest version.
 
 You may be asked by `git pull` to "identify yourself". If this is the case, simply follow the instructions on the screen to set your GitHub e-mail.
+
+You will also be presented with command you can use to return to previous version in case that things go awry. You will need to restore the backup manually to recover your data.
 
 > **Note:** This guide assumes that you have originally git cloned Misago to your home directory. If you have cloned it elsewhere, you will have to run `cd` with custom path.


### PR DESCRIPTION
New `./appctl upgrade` flow does`git pull` for user, so we can backup data before new code is pulled from github.